### PR TITLE
`jsdom`, `@types/jsdom`をアップデート

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
 	},
 	"homepage": "https://github.com/YUUKIToriyama/komoro-soba#readme",
 		"devDependencies": {
-				"@types/jsdom": "^16.2.14",
+				"@types/jsdom": "^21.1.2",
 				"@types/node": "^20.5.8",
 				"esbuild-runner": "^2.2.2",
 				"rimraf": "^5.0.1",
 				"typescript": "^5.2.2"
 		},
 		"dependencies": {
-				"jsdom": "^19.0.0"
+				"jsdom": "^22.1.0"
 		}
 }


### PR DESCRIPTION
- jsdomを19.0.0から22.1.0にバージョンアップ
- 修正前と修正後で`output`の中身に差分がないことを確認